### PR TITLE
Adding analyzed signal logs

### DIFF
--- a/CANserver/CanBus.cpp
+++ b/CANserver/CanBus.cpp
@@ -37,6 +37,8 @@ CANServer::CanBus::AnalysisItem::AnalysisItem()
     byteOrder = false;
 
     lastValue = 0;
+    driveLog = false;
+    chargeLog = false;
 }
 
 
@@ -193,6 +195,8 @@ void CANServer::CanBus::saveDynamicAnalysisFile(const char* itemName)
         doc["so"] =  analysisItem->signalOffset;
         doc["s"] =  analysisItem->isSigned;
         doc["bo"] =  analysisItem->byteOrder;
+        doc["dl"] = analysisItem->driveLog;
+        doc["cl"] = analysisItem->chargeLog;
 
         // Serialize JSON to file
         if (serializeJson(doc, file) == 0) 
@@ -258,6 +262,8 @@ void CANServer::CanBus::_loadDynamicAnalysisConfiguration()
             newAnalysisItem->signalOffset = doc["so"];
             newAnalysisItem->isSigned = doc["s"];
             newAnalysisItem->byteOrder = doc["bo"];
+            newAnalysisItem->driveLog = doc["dl"];
+            newAnalysisItem->chargeLog = doc["cl"];
             
             const char* name = fileName.c_str() + 3;
             _analysisItems.insert(AnalysisItemPair(name, newAnalysisItem));

--- a/CANserver/CanBus.h
+++ b/CANserver/CanBus.h
@@ -24,6 +24,8 @@ namespace CANServer
             int signalOffset;
             bool isSigned;
             bool byteOrder;
+            bool driveLog;
+            bool chargeLog;
 
             float lastValue;
         };

--- a/CANserver/Logging.cpp
+++ b/CANserver/Logging.cpp
@@ -336,7 +336,7 @@ void CANServer::Logging::handleMessage(CAN_FRAME *frame, const uint8_t busId)
                         for (CANServer::CanBus::AnalysisItemMap::const_iterator iter = canbusInstance->dynamicAnalysisItems()->begin(); iter != canbusInstance->dynamicAnalysisItems()->end(); ++iter)
                         {
                             if(iter->second->driveLog == 1){
-                                tempRow = tempRow + "," + iter->second->lastValue;
+                                tempRow = tempRow + "," + String(iter->second->lastValue,6);
                             }
                         }
                         it->second.fileHandle.println(tempRow);
@@ -360,7 +360,7 @@ void CANServer::Logging::handleMessage(CAN_FRAME *frame, const uint8_t busId)
                         for (CANServer::CanBus::AnalysisItemMap::const_iterator iter = canbusInstance->dynamicAnalysisItems()->begin(); iter != canbusInstance->dynamicAnalysisItems()->end(); ++iter)
                         {
                             if(iter->second->chargeLog == 1){
-                                tempRow = tempRow + "," + iter->second->lastValue;
+                                tempRow = tempRow + "," + String(iter->second->lastValue,6);
                             }
                         }
                         it->second.fileHandle.println(tempRow);

--- a/CANserver/Logging.cpp
+++ b/CANserver/Logging.cpp
@@ -85,7 +85,7 @@ void CANServer::Logging::setup()
     {
         //Analyzed Charge Signals logging
         LogDetails_t logDetails;
-        logDetails.prefName = String("chargedrive");
+        logDetails.prefName = String("logcharge");
         logDetails.enabled = _prefs.getBool(logDetails.prefName.c_str(), false);
         logDetails.path = String(CHARGELOGNAME);
         logDetails.usageCounter = 0;
@@ -327,19 +327,21 @@ void CANServer::Logging::handleMessage(CAN_FRAME *frame, const uint8_t busId)
                     String tempRow = String(_currentTimeOfDay.tv_sec);
                     CANServer::CanBus *canbusInstance = CANServer::CanBus::instance();
                     CANServer::CanBus::AnalysisItemMap::const_iterator found_it = canbusInstance->dynamicAnalysisItems()->find("Gear");
-                    gearNUM = found_it->second->lastValue;
-
-                    if((currentLogMillis - previousDriveLogcycle >= DRIVELOGGING_INTERVAL) && (gearNUM == 2 || gearNUM == 4))
+                    if(found_it != canbusInstance->dynamicAnalysisItems()->end())
                     {
-                        previousDriveLogcycle = currentLogMillis;
-                        CANServer::CanBus *canbusInstance = CANServer::CanBus::instance();
-                        for (CANServer::CanBus::AnalysisItemMap::const_iterator iter = canbusInstance->dynamicAnalysisItems()->begin(); iter != canbusInstance->dynamicAnalysisItems()->end(); ++iter)
+                        gearNUM = found_it->second->lastValue;
+
+                        if((currentLogMillis - previousDriveLogcycle >= DRIVELOGGING_INTERVAL) && (gearNUM == 2 || gearNUM == 4))
                         {
-                            if(iter->second->driveLog == 1){
-                                tempRow = tempRow + "," + String(iter->second->lastValue,6);
+                            previousDriveLogcycle = currentLogMillis;
+                            for (CANServer::CanBus::AnalysisItemMap::const_iterator iter = canbusInstance->dynamicAnalysisItems()->begin(); iter != canbusInstance->dynamicAnalysisItems()->end(); ++iter)
+                            {
+                                if(iter->second->driveLog == 1){
+                                    tempRow = tempRow + "," + String(iter->second->lastValue,6);
+                                }
                             }
+                            it->second.fileHandle.println(tempRow);
                         }
-                        it->second.fileHandle.println(tempRow);
                     }
                     break;
                 }
@@ -351,19 +353,21 @@ void CANServer::Logging::handleMessage(CAN_FRAME *frame, const uint8_t busId)
                     String tempRow = String(_currentTimeOfDay.tv_sec);
                     CANServer::CanBus *canbusInstance = CANServer::CanBus::instance();
                     CANServer::CanBus::AnalysisItemMap::const_iterator found_it = canbusInstance->dynamicAnalysisItems()->find("UIChargeStatus");
-                    chargeStatus = found_it->second->lastValue;
-
-                    if((currentLogMillis - previousChargeLogcycle >= CHARGELOGGING_INTERVAL) && chargeStatus == 3)
+                    if(found_it != canbusInstance->dynamicAnalysisItems()->end())
                     {
-                        previousChargeLogcycle = currentLogMillis;
-                        CANServer::CanBus *canbusInstance = CANServer::CanBus::instance();
-                        for (CANServer::CanBus::AnalysisItemMap::const_iterator iter = canbusInstance->dynamicAnalysisItems()->begin(); iter != canbusInstance->dynamicAnalysisItems()->end(); ++iter)
+                        chargeStatus = found_it->second->lastValue;
+
+                        if((currentLogMillis - previousChargeLogcycle >= CHARGELOGGING_INTERVAL) && chargeStatus == 3)
                         {
-                            if(iter->second->chargeLog == 1){
-                                tempRow = tempRow + "," + String(iter->second->lastValue,6);
+                            previousChargeLogcycle = currentLogMillis;
+                            for (CANServer::CanBus::AnalysisItemMap::const_iterator iter = canbusInstance->dynamicAnalysisItems()->begin(); iter != canbusInstance->dynamicAnalysisItems()->end(); ++iter)
+                            {
+                                if(iter->second->chargeLog == 1){
+                                    tempRow = tempRow + "," + String(iter->second->lastValue,6);
+                                }
                             }
+                            it->second.fileHandle.println(tempRow);
                         }
-                        it->second.fileHandle.println(tempRow);
                     }
                     break;
                 }

--- a/CANserver/Logging.h
+++ b/CANserver/Logging.h
@@ -17,6 +17,8 @@ namespace CANServer
             LogType_Unknown = 0,
             LogType_Raw = 1,
             LogType_Interval = 2,
+            LogType_Drive = 3,
+            LogType_Charge = 4,
             LogType_Serial = 50,
         } LogType;
 

--- a/CANserver/WebServer.cpp
+++ b/CANserver/WebServer.cpp
@@ -312,6 +312,8 @@ detailsNode["filesize"] = logginginstance->fileSize(logtype);\
                 
                 LOGSettingsUpdateHelper("rawlog", CANServer::Logging::LogType_Raw);
                 LOGSettingsUpdateHelper("intervallog", CANServer::Logging::LogType_Interval);
+                LOGSettingsUpdateHelper("drivelog", CANServer::Logging::LogType_Drive);
+                LOGSettingsUpdateHelper("chargelog", CANServer::Logging::LogType_Charge);
                 LOGSettingsUpdateHelper("seriallog", CANServer::Logging::LogType_Serial);
                 
                 JsonObject sdDetailsNode = doc.createNestedObject("sddetails");
@@ -342,6 +344,14 @@ detailsNode["filesize"] = logginginstance->fileSize(logtype);\
                     else if (logid->value() == "intervallog")
                     {
                         logType = CANServer::Logging::LogType_Interval;
+                    }
+                    else if (logid->value() == "drivelog")
+                    {
+                        logType = CANServer::Logging::LogType_Drive;
+                    }
+                    else if (logid->value() == "chargelog")
+                    {
+                        logType = CANServer::Logging::LogType_Charge;
                     }
 
                     if (logType != CANServer::Logging::LogType_Unknown)
@@ -378,6 +388,14 @@ detailsNode["filesize"] = logginginstance->fileSize(logtype);\
                     else if (logid->value() == "intervallog")
                     {
                         logType = CANServer::Logging::LogType_Interval;
+                    }
+                    else if (logid->value() == "drivelog")
+                    {
+                        logType = CANServer::Logging::LogType_Drive;
+                    }
+                    else if (logid->value() == "chargelog")
+                    {
+                        logType = CANServer::Logging::LogType_Charge;
                     }
 
                     if (logType != CANServer::Logging::LogType_Unknown)
@@ -419,6 +437,8 @@ else\
 
                 LOGSettingsSaveHelper("rawlog", CANServer::Logging::LogType_Raw);
                 LOGSettingsSaveHelper("intervallog", CANServer::Logging::LogType_Interval);
+                LOGSettingsSaveHelper("drivelog", CANServer::Logging::LogType_Drive);
+                LOGSettingsSaveHelper("chargelog", CANServer::Logging::LogType_Charge);
                 LOGSettingsSaveHelper("seriallog", CANServer::Logging::LogType_Serial);
 
                 CANServer::Logging::instance()->saveConfiguraiton();
@@ -520,6 +540,24 @@ littleendian: true
                         analysisItem->byteOrder = false;
                     }
 
+                    if (request->hasParam("drivelog", true) && request->getParam("drivelog", true)->value() == "true")
+                    {
+                        analysisItem->driveLog = true;
+                    }
+                    else
+                    {
+                        analysisItem->driveLog = false;
+                    }
+
+                    if (request->hasParam("chargelog", true) && request->getParam("chargelog", true)->value() == "true")
+                    {
+                        analysisItem->chargeLog = true;
+                    }
+                    else
+                    {
+                        analysisItem->chargeLog = false;
+                    }
+
                     //Pause running of the items so we can modify them
                     CANServer::CanBus *canbusInstance = CANServer::CanBus::instance();
                     canbusInstance->pauseDynamicAnalysis();
@@ -588,6 +626,8 @@ littleendian: true
                         doc["signalOffset"] = it->second->signalOffset;
                         doc["isSigned"] = it->second->isSigned;
                         doc["byteOrder"] = it->second->byteOrder;
+                        doc["driveLog"] = it->second->driveLog;
+                        doc["chargeLog"] = it->second->chargeLog;
 
                         response->setLength();
                         request->send(response);

--- a/ui-data/html/analysis.html
+++ b/ui-data/html/analysis.html
@@ -109,7 +109,8 @@
                   "s" in parsedJson &&
                   "bo" in parsedJson &&
                   "v" in parsedJson &&
-                  "dl" in parsedJson) {
+                  "dl" in parsedJson &&
+                  "cl" in parsedJson) {
                 //This looks like what we want.  Lets deal with it.
                 var itemName = parsedJson.n;
                 

--- a/ui-data/html/analysis.html
+++ b/ui-data/html/analysis.html
@@ -108,9 +108,7 @@
                   "so" in parsedJson &&
                   "s" in parsedJson &&
                   "bo" in parsedJson &&
-                  "v" in parsedJson &&
-                  "dl" in parsedJson &&
-                  "cl" in parsedJson) {
+                  "v" in parsedJson) {
                 //This looks like what we want.  Lets deal with it.
                 var itemName = parsedJson.n;
                 
@@ -138,8 +136,11 @@
                 foundItemRow.querySelector('input.signaloffset').value = parsedJson.so;
                 foundItemRow.querySelector('input.issigned').checked = parsedJson.s == true;
                 foundItemRow.querySelector('input.littleendian').checked = parsedJson.bo == true;
-                foundItemRow.querySelector('input.drivelog').checked = parsedJson.dl == true;
-                foundItemRow.querySelector('input.chargelog').checked = parsedJson.cl == true;
+                if ("dl" in parsedJson &&
+                  "cl" in parsedJson){
+                    foundItemRow.querySelector('input.drivelog').checked = parsedJson.dl == true;
+                    foundItemRow.querySelector('input.chargelog').checked = parsedJson.cl == true;
+                }
                 
                 event.preventDefault();      
                 

--- a/ui-data/html/analysis.html
+++ b/ui-data/html/analysis.html
@@ -26,6 +26,8 @@
                 <th style="width: 72px;">Is Signed</th>
                 <th style="width: 96px;">Little Endian</th>
                 <th style="width: 68px;">Value</th>
+                <th style="width: 96px;">Drive Log</th>
+                <th style="width: 96px;">Charge Log</th>
                 <th style="width: 50px;">Action</th>
               </tr>
             </thead>
@@ -64,6 +66,12 @@
                   <input class="littleendian" name="littleendian" type="checkbox">
                 </td>
                 <td class="value" data-title="Value"> --- </td>
+                <td data-title="Drive Log">
+                  <input class="drivelog" name="drivelog" type="checkbox">
+                </td>
+                <td data-title="Charge Log">
+                  <input class="chargelog" name="chargelog" type="checkbox">
+                </td>
                 <td data-title="Action">
                   <a class="copy" alt="Copy" title="Copy"><img style="vertical-align: text-top;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAIpSURBVDjLddM9aFRBFIbh98zM3WyybnYVf4KSQjBJJVZBixhRixSaShtBMKUoWomgnaCxsJdgIQSstE4nEhNREgyoZYhpkogkuMa4/3fuHIu7gpLd00wz52POMzMydu/Dy958dMwYioomIIgqDa+VnWrzebNUejY/NV6nQ8nlR4ufXt0fzm2WgxUgqBInAWdhemGbpcWNN9/XN27PPb1QbRdgjEhPqap2ZUv5+iOwvJnweT1mT5djZKjI6Ej/udz+wt1OJzAKYgWyDjJWyFghmzFsbtcY2gsTJwv09/Vc7RTgAEQgsqAKaoWsM8wu/z7a8B7vA8cHD3Fr+ktFgspO3a+vrdVfNEulJ/NT4zWngCBYY1oqSghKI465fvYwW+VAatPX07IZmF7YfrC0uDE8emPmilOFkHYiBKxAxhmSRPlZVVa2FGOU2Ad2ap4zg92MDBXJZczFmdflx05VEcAZMGIIClZASdesS2cU/dcm4sTBArNzXTcNakiCb3/HLRsn4Fo2qyXh3WqDXzUlcgYnam3Dl4Hif82dbOiyiBGstSjg4majEpl8rpCNUQUjgkia0M5GVAlBEBFUwflEv12b/Hig6SmA1iDtzhcsE6eP7LIxAchAtwNVxc1MnhprN/+lh0txErxrPZVdFdRDEEzHT6LWpTbtq+HLSDDiOm2o1uqlyOT37bIhHdKaXoL6pqhq24Dzd96/tUYGwPSBVv7atFglaFIu5KLuPxeX/xsp7aR6AAAAAElFTkSuQmCC"></a>
                   <a class="save" alt="Save" title="Save"><img style="vertical-align: text-top;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAH+SURBVBgZBcE9i11VGAbQtc/sO0OCkqhghEREAwpWAWUg8aMVf4KFaJEqQtAipTZWViKiCGOh2Ap2gmJhlSIWFsFOxUK0EsUM3pl79n4f12qHb3z3Fh7D83gC95GOJsDe0ixLk5Qq/+xv/Lw9Xd+78/HLX3Y8fXTr2nWapy4eCFKxG7Fby97SnDlYtMbxthyfzHO//nl85fNvfvnk8MbX5xa8IHx1518Vkrj54Q+qQms2vVmWZjdiu5ZR2rT01166/NCZg/2PFjwSVMU6yjoC1oq+x6Y3VbHdlXWExPd379nf7Nmejv2Os6OC2O4KLK0RNn3RNCdr2Z5GJSpU4o+/TkhaJ30mEk5HwNuvX7Hpi76wzvjvtIwqVUSkyjqmpHS0mki8+9mPWmuWxqYvGkbFGCUAOH/+QevYI9GFSqmaHr5wkUYTAlGhqiRRiaqiNes6SOkwJwnQEqBRRRJEgkRLJGVdm6R0GLMQENE0EkmkSkQSVVMqopyuIaUTs0J455VLAAAAAODW0U/GiKT0pTWziEj44PZ1AAAAcPPqkTmH3QiJrlEVDXDt0qsAAAAAapa5BqUnyaw0Am7//gUAAAB49tEXzTmtM5KkV/y2G/X4M5fPao03n/sUAAAAwIX7y5yBv9vhjW/fT/IkuSp5gJKElKRISYoUiSRIyD1tufs/IXxui20QsKIAAAAASUVORK5CYII="></a>
@@ -100,7 +108,8 @@
                   "so" in parsedJson &&
                   "s" in parsedJson &&
                   "bo" in parsedJson &&
-                  "v" in parsedJson) {
+                  "v" in parsedJson &&
+                  "dl" in parsedJson) {
                 //This looks like what we want.  Lets deal with it.
                 var itemName = parsedJson.n;
                 
@@ -128,6 +137,8 @@
                 foundItemRow.querySelector('input.signaloffset').value = parsedJson.so;
                 foundItemRow.querySelector('input.issigned').checked = parsedJson.s == true;
                 foundItemRow.querySelector('input.littleendian').checked = parsedJson.bo == true;
+                foundItemRow.querySelector('input.drivelog').checked = parsedJson.dl == true;
+                foundItemRow.querySelector('input.chargelog').checked = parsedJson.cl == true;
                 
                 event.preventDefault();      
                 
@@ -169,6 +180,8 @@
                 itemRow.querySelector('input.signaloffset').value = data.signalOffset;
                 itemRow.querySelector('input.issigned').checked = data.isSigned == true;
                 itemRow.querySelector('input.littleendian').checked = data.byteOrder == true;
+                itemRow.querySelector('input.drivelog').checked = data.driveLog == true;
+                itemRow.querySelector('input.chargelog').checked = data.chargeLog == true;
                 
                 let saveLinkEl = itemRow.querySelector('a.save');
                 saveLinkEl.onclick = function () { saveItem(this) };
@@ -283,6 +296,8 @@
             jsonToCopy['s'] = rowToWorkOn.querySelector('input.issigned').checked;
             jsonToCopy['bo'] = rowToWorkOn.querySelector('input.littleendian').checked;
             jsonToCopy['v'] = 1;
+            jsonToCopy['dl'] = rowToWorkOn.querySelector('input.drivelog').checked;
+            jsonToCopy['cl'] = rowToWorkOn.querySelector('input.chargelog').checked;
             
             var id = "mycustom-clipboard-textarea-hidden-id";
             var existsTextarea = document.getElementById(id);
@@ -357,6 +372,8 @@
                 postInfo.append('signaloffset', Number(rowToWorkOn.querySelector('input.signaloffset').value));
                 postInfo.append('issigned', rowToWorkOn.querySelector('input.issigned').checked);
                 postInfo.append('littleendian', rowToWorkOn.querySelector('input.littleendian').checked);
+                postInfo.append('drivelog', rowToWorkOn.querySelector('input.drivelog').checked);
+                postInfo.append('chargelog', rowToWorkOn.querySelector('input.chargelog').checked);
                 
                 postData('/analysis_save', postInfo).then(() => {
                   window.location = "/analysis";

--- a/user-data/a/BSL
+++ b/user-data/a/BSL
@@ -6,5 +6,7 @@
     "so": 0,
     "s": false,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": false,
+    "cl": false
 }

--- a/user-data/a/BSR
+++ b/user-data/a/BSR
@@ -6,5 +6,7 @@
     "so": 0,
     "s": false,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": false,
+    "cl": false
 }

--- a/user-data/a/BattAmps
+++ b/user-data/a/BattAmps
@@ -6,5 +6,7 @@
     "so": 0,
     "s": true,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": true,
+    "cl": true
 }

--- a/user-data/a/BattCoolantRate
+++ b/user-data/a/BattCoolantRate
@@ -6,5 +6,7 @@
     "so": 0,
     "s": false,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": true,
+    "cl": true
 }

--- a/user-data/a/BattVolts
+++ b/user-data/a/BattVolts
@@ -6,5 +6,7 @@
     "so": 0,
     "s": false,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": true,
+    "cl": true
 }

--- a/user-data/a/DisplayOn
+++ b/user-data/a/DisplayOn
@@ -6,5 +6,7 @@
     "so": 0,
     "s": false,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": false,
+    "cl": false
 }

--- a/user-data/a/DistanceUnitMiles
+++ b/user-data/a/DistanceUnitMiles
@@ -6,5 +6,7 @@
     "so": 0,
     "s": false,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": false,
+    "cl": false
 }

--- a/user-data/a/Gear
+++ b/user-data/a/Gear
@@ -1,0 +1,12 @@
+{
+    "fid": 280,
+    "sb": 21,
+    "bl": 3,
+    "f": 1,
+    "so": 0,
+    "s": false,
+    "bo": true,
+    "v": 1,
+    "dl": false,
+    "cl": false
+}

--- a/user-data/a/MaxDisChg
+++ b/user-data/a/MaxDisChg
@@ -6,5 +6,7 @@
     "so": 0,
     "s": false,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": true,
+    "cl": false
 }

--- a/user-data/a/MaxRegen
+++ b/user-data/a/MaxRegen
@@ -6,5 +6,7 @@
     "so": 0,
     "s": false,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": true,
+    "cl": false
 }

--- a/user-data/a/MinBattTemp
+++ b/user-data/a/MinBattTemp
@@ -6,5 +6,7 @@
     "so": -25,
     "s": false,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": true,
+    "cl": true
 }

--- a/user-data/a/PTCoolantRate
+++ b/user-data/a/PTCoolantRate
@@ -6,5 +6,7 @@
     "so": 0,
     "s": false,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": true
+    "cl": true
 }

--- a/user-data/a/RearTorque
+++ b/user-data/a/RearTorque
@@ -6,5 +6,7 @@
     "so": 0,
     "s": true,
     "bo": true,
-    "v": 1
+    "v": 1,
+    "dl": true,
+    "cl": true
 }

--- a/user-data/a/UIChargeStatus
+++ b/user-data/a/UIChargeStatus
@@ -1,0 +1,12 @@
+{
+    "fid": 530,
+    "sb": 11,
+    "bl": 3,
+    "f": 1,
+    "so": 0,
+    "s": false,
+    "bo": true,
+    "v": 1,
+    "dl": false,
+    "cl": false
+}

--- a/user-data/a/VehSpeed
+++ b/user-data/a/VehSpeed
@@ -6,5 +6,7 @@
     "f": 0.08,
     "so": -40,
     "s": false,
-    "bo": true
+    "bo": true,
+    "dl": true,
+    "cl": false
 }


### PR DESCRIPTION
This PR should contain all the files for the charge and drive logs. 
Charge log only runs when charging, relying on UIChargeStatus == 3.
Drive log only runs when driving (D/R), relying on Gear == 2 || Gear == 4. 
Currently set to log every 5 seconds. 
Signals are selected in the analysis window under drive or charge. 
Edits to user-data/a may require initialflash.bin, but I'm not positive on that.