### PR TITLE
Add support for numeric analysis name

### DIFF
--- a/ui-data/html/analysis.html
+++ b/ui-data/html/analysis.html
@@ -260,7 +260,7 @@
           
               if (shouldDelete) {
                 let postInfo = new FormData();
-                postInfo.append('name', rowToDelete.getAttribute('id'));
+                postInfo.append('name', rowToDelete.getAttribute('id').replace(/^item/, ''));
                 
                 postData('/analysis_delete', postInfo).then(() => {
                   window.location = "/analysis";
@@ -348,7 +348,7 @@
               if (foundNameCount == 1) {
                 let postInfo = new FormData();
                 postInfo.append('state', rowToWorkOn.getAttribute('id') === "----new----" ? 'new' : 'update');
-                postInfo.append('origName', rowToWorkOn.getAttribute('id'));
+                postInfo.append('origName', rowToWorkOn.getAttribute('id').replace(/^item/, ''));
                 postInfo.append('name', newName);
                 postInfo.append('frameid', hexToDec(rowToWorkOn.querySelector('input.frameid').value.substr(2)));
                 postInfo.append('startbit', Number(rowToWorkOn.querySelector('input.startbit').value));

--- a/ui-data/html/analysis.html
+++ b/ui-data/html/analysis.html
@@ -106,7 +106,7 @@
                 
                 //Lets see if we already have this name and need to change its values
                 var alertString = "";
-                var foundItemRow = document.querySelector("tr#" + itemName);
+                var foundItemRow = document.querySelector("tr#item" + itemName);
                 if (foundItemRow) {
                   //An existing entry.  Lets update it.
                   alertString = itemName + ' analysis item has been updated.  Please save it if you wish to keep the changes.';
@@ -160,7 +160,7 @@
               // ajax request
               getJSON('/analysis_info?item=' + itemId).then(data => {
                 
-                let itemRow = analysis.querySelector("tr#" + itemId);
+                let itemRow = analysis.querySelector("tr#item" + itemId);
                 
                 itemRow.querySelector('input.frameid').value = '0x' + decToHex(data.frameid, 3);
                 itemRow.querySelector('input.startbit').value = data.startBit;
@@ -205,7 +205,7 @@
               itemsToLoad.push(itemId);
               
               let itemRow = analysis.querySelector("tfoot tr#rowtemplate").cloneNode(true);
-              itemRow.setAttribute('id', itemId);
+              itemRow.setAttribute('id', "item"+itemId);
               show(itemRow);
               
               inputBoxEl = itemRow.querySelector('input.name');
@@ -373,7 +373,7 @@
           const updateLoad = () => {
             getJSON('/analysis_update').then(data => {
               Object.keys(data).forEach(itemId => {
-                let itemRow = analysis.querySelector('tr#' + itemId + ' td.value');
+                let itemRow = analysis.querySelector('tr#item' + itemId + ' td.value');
                 if (itemRow) {
                   itemRow.innerHTML = data[itemId];
                 }

--- a/ui-devserver/index.js
+++ b/ui-devserver/index.js
@@ -73,6 +73,15 @@ const analysis_load_json = {
         signalOffset: 0,
         isSigned: true,
         byteOrder: true
+    },
+    "123a": {
+        frameid: 306,
+        startBit: 16,
+        bitLength: 16,
+        factor: -0.1,
+        signalOffset: 0,
+        isSigned: true,
+        byteOrder: true
     }
 };
 
@@ -213,6 +222,10 @@ app.get('/analysis_update', (req, res) => {
     res.json(analysis_update_json);
 });
 
+app.get('/analysis_info', (req, res) => {
+    const { item } = req.query;
+    res.json(analysis_load_json[item]);
+});
 
 
 app.get('/processing_script', (req, res) => {

--- a/ui-devserver/index.js
+++ b/ui-devserver/index.js
@@ -8,7 +8,7 @@ const express = require('express');
 const path =  require('path');
 
 const app = express();
-const dataDir = path.join(__dirname, '../data');
+const dataDir = path.join(__dirname, '../ui-data');
 
 // mock objects
 
@@ -243,6 +243,6 @@ app.get('/processing_stats', (req, res) => {
 
 
 // fallback other assets like CSS and JS
-app.use(express.static('../data'));
+app.use(express.static('../ui-data'));
 
 app.listen(8080, () => console.log('Started CANserver UI development server on port 8080'));


### PR DESCRIPTION
Should quickfix the issue experienced in https://github.com/joshwardell/CANserver/issues/19

All identifiers in analysis are now prefixed with `item` so that they can no longer have a numeric prefix and crash runtime.